### PR TITLE
Re-Initialize ui-dropdown after content changes and the items re-render.

### DIFF
--- a/addon/components/ui-dropdown-item.js
+++ b/addon/components/ui-dropdown-item.js
@@ -19,6 +19,6 @@ export default Ember.SelectOption.extend({
   }.on('didInsertElement'),
 
   unbindData: function() {
-    this.$().removeData('value')
+    this.$().removeData('value');
   }.on('willDestroyElement')
 });

--- a/addon/components/ui-dropdown.js
+++ b/addon/components/ui-dropdown.js
@@ -43,7 +43,7 @@ export default Ember.Select.extend(Base, DataAttributes, {
     //
     // Without this, Dropdown Items will not be clickable if the content
     // is set after the initial render.
-    Ember.run.schedule('afterRender', this, this.didInsertElement);
+    Ember.run.scheduleOnce('afterRender', this, this.didInsertElement);
   }.observes('content'),
 
   set_value: function() {

--- a/addon/components/ui-dropdown.js
+++ b/addon/components/ui-dropdown.js
@@ -43,9 +43,7 @@ export default Ember.Select.extend(Base, DataAttributes, {
     //
     // Without this, Dropdown Items will not be clickable if the content
     // is set after the initial render.
-    Ember.run.schedule('afterRender', this, function() {
-      return this.$()[this.get("module")](this.settings(this.get("module")));
-    });
+    Ember.run.schedule('afterRender', this, this.didInsertElement);
   }.observes('content'),
 
   set_value: function() {

--- a/addon/components/ui-dropdown.js
+++ b/addon/components/ui-dropdown.js
@@ -33,8 +33,20 @@ export default Ember.Select.extend(Base, DataAttributes, {
   },
 
   onUpdate: function() {
-    return Ember.run.scheduleOnce('afterRender', this, this.set_value);
+    return this.$()[this.get("module")](this.settings(this.get("module")));
   }.observes('value'),
+
+  onContentChange: function() {
+    // Wait for the afterRender portion of the Run Loop to complete after
+    // after a content change. Once that happens, re-initialize the
+    // Semantic component the same way as Semantic.BaseMixin
+    //
+    // Without this, Dropdown Items will not be clickable if the content
+    // is set after the initial render.
+    Ember.run.schedule('afterRender', this, function() {
+      return this.$()[this.get("module")](this.settings(this.get("module")));
+    });
+  }.observes('content'),
 
   set_value: function() {
     var dropdownValue, inputValue, _ref;

--- a/addon/components/ui-dropdown.js
+++ b/addon/components/ui-dropdown.js
@@ -33,7 +33,7 @@ export default Ember.Select.extend(Base, DataAttributes, {
   },
 
   onUpdate: function() {
-    return this.$()[this.get("module")](this.settings(this.get("module")));
+    return Ember.run.scheduleOnce('afterRender', this, this.set_value);
   }.observes('value'),
 
   onContentChange: function() {

--- a/addon/components/ui-popup.js
+++ b/addon/components/ui-popup.js
@@ -4,7 +4,7 @@ import Base from '../mixins/base';
 export default Ember.Component.extend(Base, {
   module: 'popup',
   contentChanges: function() {
-    this.didInsertElement()
+    this.didInsertElement();
   }.observes('content'),
   attributeBindings: [ 'content:data-content' ]
 });

--- a/addon/views/ui-modal.js
+++ b/addon/views/ui-modal.js
@@ -2,4 +2,4 @@ import Ember from 'ember';
 import ModalMixin from '../mixins/modal';
 
 export default Ember.View.extend(ModalMixin, {
-})
+});


### PR DESCRIPTION
This is if fix for issue #8.

It takes advantage of the Ember Run Loop to wait until after the new dropdown items render before re-initializing the Semantic component. After this re-initialization, the items are now selectable and everything works as expected.