### PR TITLE
Use `set value` rather than `set selected`

### DIFF
--- a/addon/components/ui-dropdown-item.js
+++ b/addon/components/ui-dropdown-item.js
@@ -19,6 +19,6 @@ export default Ember.SelectOption.extend({
   }.on('didInsertElement'),
 
   unbindData: function() {
-    this.$().removeData('value')
+    this.$().removeData('value');
   }.on('willDestroyElement')
 });

--- a/addon/components/ui-dropdown.js
+++ b/addon/components/ui-dropdown.js
@@ -17,7 +17,7 @@ export default Ember.Select.extend(Base, DataAttributes, {
   initialize: function() {
     var value = this.get('value');
     if (typeof value !== "undefined" && value !== null) {
-      this.execute('set selected', value);
+      this.execute('set value', value);
     }
   }.on('didInsertElement'),
 
@@ -53,7 +53,7 @@ export default Ember.Select.extend(Base, DataAttributes, {
     if (inputValue == null) {
       return this.execute("restore defaults");
     } else if (inputValue !== dropdownValue) {
-      return this.execute("set selected", this.get('value'));
+      return this.execute("set value", this.get('value'));
     }
   }
 });

--- a/addon/components/ui-popup.js
+++ b/addon/components/ui-popup.js
@@ -4,7 +4,7 @@ import Base from '../mixins/base';
 export default Ember.Component.extend(Base, {
   module: 'popup',
   contentChanges: function() {
-    this.didInsertElement()
+    this.didInsertElement();
   }.observes('content'),
   attributeBindings: [ 'content:data-content' ]
 });

--- a/addon/views/ui-modal.js
+++ b/addon/views/ui-modal.js
@@ -2,4 +2,4 @@ import Ember from 'ember';
 import ModalMixin from '../mixins/modal';
 
 export default Ember.View.extend(ModalMixin, {
-})
+});

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ember-data": "1.0.0-beta.12",
     "ember-export-application-global": "^1.0.0",
     "express": "^4.8.5",
-    "glob": "^4.0.5"
+    "glob": "4.4.0"
   },
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
This is a fix for issue #13.

For some reason, using Semantic's `set selected` command wasn't properly updating the dropdown when the `value` changed. Switching to `set value` corrects the issue.