### PR TITLE
Fixing on hide error

### DIFF
--- a/addon/mixins/modal.js
+++ b/addon/mixins/modal.js
@@ -18,13 +18,16 @@ export default Ember.Mixin.create(Base, {
 
   willDestroyElement: function() {
     this._super();
-    if (!this.get('hiding')) {
-      this.execute('hide');
-    }
+    Ember.assert("Semantic modal was destoryed without being properly hidden. Don't call closeModal from the controller.", this.get('hiding'));  
   },
 
   onHide: function() {
     this.set('hiding', true);
+    var controller = this.checkControllerForAction('hide');
+    if (controller) {
+      // we don't pass in view, since you can't stop it from hiding once it starts
+      controller.send('hide');
+    }
   },
 
   onHidden: function() {
@@ -34,10 +37,10 @@ export default Ember.Mixin.create(Base, {
   },
 
   onDeny: function() {
-    var controller = this.checkControllerForAction('cancel');
+    var controller = this.checkControllerForAction('deny');
     if (controller) {
-      // if controller handles approves, they must manually call hideModal
-      controller.send('cancel', this);
+      // if controller handles approves, they must manually call view.execute('hide')
+      controller.send('deny', this);
       return false
     }
     return true;
@@ -46,7 +49,7 @@ export default Ember.Mixin.create(Base, {
   onApprove: function() {
     var controller = this.checkControllerForAction('approve');
     if (controller) {
-      // if controller handles approves, they must manually call hideModal
+      // if controller handles approves, they must manually call view.execute('hide')
       controller.send('approve', this);
       return false
     }

--- a/addon/mixins/modal.js
+++ b/addon/mixins/modal.js
@@ -25,25 +25,41 @@ export default Ember.Mixin.create(Base, {
 
   onHide: function() {
     this.set('hiding', true);
+  },
+
+  onHidden: function() {
     if (this.get('controller')) {
-      this.get('controller').send('closeModal');
+      this.get('controller').send('closeModal', this);
     }
-    return false;
   },
 
   onDeny: function() {
-    if (this.get('controller')._actions['cancel'] !== null &&
-        this.get('controller')._actions['cancel'] !== undefined) {
-      this.get('controller').send('cancel');
+    var controller = this.checkControllerForAction('cancel');
+    if (controller) {
+      // if controller handles approves, they must manually call hideModal
+      controller.send('cancel', this);
+      return false
     }
     return true;
   },
 
   onApprove: function() {
-    if (this.get('controller')._actions['approve'] !== null &&
-        this.get('controller')._actions['approve'] !== undefined) {
-      this.get('controller').send('approve');
+    var controller = this.checkControllerForAction('approve');
+    if (controller) {
+      // if controller handles approves, they must manually call hideModal
+      controller.send('approve', this);
+      return false
     }
-    return false;
+    return true;
+  },
+
+  checkControllerForAction: function(action) {
+    var controller = this.get('controller');
+    if (typeof controller !== "undefined" && controller !== null &&
+        typeof controller._actions !== "undefined" && controller._actions !== null &&
+        typeof controller._actions[action] !== "undefined" && controller._actions[action] !== null) {
+      return controller;
+    }
+    return false
   }
 });

--- a/addon/mixins/modal.js
+++ b/addon/mixins/modal.js
@@ -29,7 +29,7 @@ export default Ember.Mixin.create(Base, {
 
   onHidden: function() {
     if (this.get('controller')) {
-      this.get('controller').send('closeModal', this);
+      this.get('controller').send('closeModal');
     }
   },
 

--- a/addon/mixins/modal.js
+++ b/addon/mixins/modal.js
@@ -18,7 +18,7 @@ export default Ember.Mixin.create(Base, {
 
   willDestroyElement: function() {
     this._super();
-    Ember.assert("Semantic modal was destoryed without being properly hidden. Don't call closeModal from the controller.", this.get('hiding'));  
+    Ember.assert("Semantic modal was destoryed without being properly hidden. Don't call closeModal from the controller. Instead add an approve or deny action, and then call view.execute('hide') from the view passed in.", this.get('hiding'));  
   },
 
   onHide: function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-ui-ember",
-  "version": "0.0.1-rc.7",
+  "version": "0.0.1-rc.8",
   "title": "Semantic UI Ember",
   "description": "Semantic UI for Ember applications",
   "homepage": "http://www.semantic-ui.com",


### PR DESCRIPTION
This should fix the transition error message. Also now if the controller has an action for approve or cancel, that controller is now responsible for closing the modal.

Also, we are now passing in the view, the proper way to close the modal is to call back to the view with 
```
view.execute('hide')
```
Then the events happen in the right order for semantic 