### PR TITLE
Enables modals to work with components

### DIFF
--- a/addon/mixins/application-route.js
+++ b/addon/mixins/application-route.js
@@ -13,10 +13,15 @@ export default Ember.Mixin.create({
 
       try {
         container = this.get('container');
-        try {
-          controller = this.controllerFor(name);
-        } catch (e) {
-          controller = Ember.generateController(container, name, model);
+
+        controller = container.lookup('component:' + name);
+
+        if (Ember.isEmpty(controller)) {
+          try {
+            controller = this.controllerFor(name);
+          } catch (e) {
+            controller = Ember.generateController(container, name, model);
+          }
         }
 
         controller.set('model', model);


### PR DESCRIPTION
Adds an initial attempt to set the controller to a template. If the lookup returns undefined, then the controller is set in the usual way.

Components can be used as modal interfaces:
 ```Coffeescript
@send('openModal', 'path/to/component-name', { some_public_interface_property: 'value', closeModal: 'closeModal' } )
```
In the component handle and send closeModal action:
 ```Coffeescript
actions:
  closeModal: ->
    @sendAction('closeModal')
 ```
