### PR TITLE
introduce options to skip CSS import

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,14 @@ module.exports = {
   name: 'semantic-ui-ember',
 
   included: function (app) {
-    app.import({
-      development: 'bower_components/semantic-ui/dist/semantic.css',
-      production: 'bower_components/semantic-ui/dist/semantic.min.css'
-    });
+    var options = (app && app.options.semanticUIOptions) || {};
+
+    if(!options['skipCSS']){
+      app.import({
+        development: 'bower_components/semantic-ui/dist/semantic.css',
+        production: 'bower_components/semantic-ui/dist/semantic.min.css'
+      });
+    };
 
     app.import({
       development: 'bower_components/semantic-ui/dist/semantic.js',


### PR DESCRIPTION
If you want to do custom theming there is  no need to include the default CSS.
With this option you can skip CSS import using options in your Brocfile.js

```javascript
var app = new EmberApp({
  semanticUIOptions: {
    skipCSS: true
  }
)}
```