### PR TITLE
Fix onContentChange handler when destroyed or destroying

### DIFF
--- a/addon/components/ui-dropdown.js
+++ b/addon/components/ui-dropdown.js
@@ -44,6 +44,7 @@ export default Ember.Select.extend(Base, DataAttributes, {
     // Without this, Dropdown Items will not be clickable if the content
     // is set after the initial render.
     Ember.run.scheduleOnce('afterRender', this, function() {
+      if (this.isDestroyed || this.isDestroying) return;
       this.didInsertElement();
       this.set_value();
     });

--- a/addon/components/ui-dropdown.js
+++ b/addon/components/ui-dropdown.js
@@ -44,7 +44,7 @@ export default Ember.Select.extend(Base, DataAttributes, {
     // Without this, Dropdown Items will not be clickable if the content
     // is set after the initial render.
     Ember.run.scheduleOnce('afterRender', this, function() {
-      if (this.isDestroyed || this.isDestroying) return;
+      if (this.get('isDestroyed') || this.get('isDestroying')) return;
       this.didInsertElement();
       this.set_value();
     });


### PR DESCRIPTION
Added code to the `afterRender` handler to simply return if the view `isDestroyed` or `isDestroying` to prevent console errors.

The code needs to be in the `afterRender` handler rather than before registering as the view may not be in the process of being destroyed until we get to the handler function.