### PR TITLE
Fallback for Controller = 'undefined'

### DIFF
--- a/addon/mixins/application-route.js
+++ b/addon/mixins/application-route.js
@@ -15,6 +15,9 @@ export default Ember.Mixin.create({
         container = this.get('container');
         try {
           controller = this.controllerFor(name);
+          if (Ember.isBlank(controller)) {
+            throw "Controller not found";
+          }
         } catch (e) {
           controller = Ember.generateController(container, name, model);
         }


### PR DESCRIPTION
Occasionally, this.controllerFor(name) returns 'undefined' which will then throw an error when attempting to set the model.

This is a fallback that will throw an error anytime the controller is 'undefined' or otherwise blank