### PR TITLE
Update README.md -> SemanticRouteMixin path was wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ This provides the `openModal` and `closeModal` actions that allows modals to be 
   * pods/application/route.js
 
 ```javascript
-import SemanticRouteMixin from 'semantic-ui-ember/mixins/application-route';
+import SemanticRouteMixin from 'semantic-ui-ember/mixins/modal';
 
 var ApplicationRoute = Ember.Route.extend(SemanticRouteMixin, {});
 ```


### PR DESCRIPTION
In README.md you guys mentioned to wrong path for SemanticRouteMixin.