### PR TITLE
Small fix to onChange action syntax for ui-dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ export default Ember.Controller.extend({
 
 ### Template
 ```handlebars
-{{#ui-dropdown class="selection" onChange(action 'update_selected')}}
+{{#ui-dropdown class="selection" onChange=(action 'update_selected')}}
   <div class="default text">Select an item</div>
   <i class="dropdown icon"></i>
   <div class="menu">


### PR DESCRIPTION
Added in a missing equal sign for ui-dropdown usage docs.