### PR TITLE
Binding a dropdown to selected instead of value

### DIFF
--- a/addon/components/ui-dropdown.js
+++ b/addon/components/ui-dropdown.js
@@ -15,6 +15,7 @@ export default Ember.Component.extend(Base, DataAttributes, {
 
     var value = this.get('value');
     if (typeof value !== "undefined" && value !== null) {
+      Ember.deprecate('Bind to selected on ui-dropdown instead of value as semantic doesn\'t update the display when the value is set', false);
       this.execute('set value', value);
     }
   }),

--- a/addon/components/ui-dropdown.js
+++ b/addon/components/ui-dropdown.js
@@ -9,21 +9,18 @@ export default Ember.Component.extend(Base, DataAttributes, {
   value: null,
 
   initialize: Ember.on('didInsertElement', function() {
+    var selected = this.get('selected');
+    if (typeof selected !== "undefined" && selected !== null) {
+      this.execute('set selected', selected);
+    }
+
     var value = this.get('value');
     if (typeof value !== "undefined" && value !== null) {
-      this.execute('set selected', value);
+      this.execute('set value', value);
     }
   }),
 
   _onChange: function(value, text, $element) {
-    this._super();
-    if (typeof value === "undefined" && $element) {
-      // The initial set selected doesn't have an value. This is potentially a problem
-      // within the main Semantic library
-      //
-      // https://github.com/Semantic-Org/Semantic-UI/blob/master/src/definitions/modules/dropdown.js#L85
-      value = $element.data('value');
-    }
-    return this.set('value', value);
+    this.set('value', value);
   }
 });

--- a/addon/components/ui-dropdown.js
+++ b/addon/components/ui-dropdown.js
@@ -6,7 +6,6 @@ export default Ember.Component.extend(Base, DataAttributes, {
   module: 'dropdown',
   classNames: [ 'ui', 'dropdown' ],
   tagName: 'div',
-  value: null,
 
   initialize: Ember.on('didInsertElement', function() {
     var selected = this.get('selected');
@@ -20,7 +19,7 @@ export default Ember.Component.extend(Base, DataAttributes, {
     }
   }),
 
-  _onChange: function(value, text, $element) {
-    this.set('value', value);
+  _onChange: function(value/*, text, $element*/) {
+    this.set('selected', value);
   }
 });

--- a/tests/integration/components/ui-dropdown-test.js
+++ b/tests/integration/components/ui-dropdown-test.js
@@ -10,7 +10,7 @@ test('it renders from an array', function(assert) {
 
   this.set('people', [ "Sherlock Homes", "Patrick Bateman" ]);
   this.render(hbs`
-    {{#ui-dropdown value=value}}
+    {{#ui-dropdown selected=selected}}
       <div class='menu'>
       {{#each people as |person|}}
         <div class='item' data-value={{person}}>{{person}}</div>
@@ -20,10 +20,10 @@ test('it renders from an array', function(assert) {
   `);
 
   assert.equal(this.$('.item').length, 2);
-  assert.equal(this.get('value'), undefined);
+  assert.equal(this.get('selected'), undefined);
 
   this.$(".menu .item[data-value='Sherlock Homes']").click();
-  assert.equal(this.get('value'), 'Sherlock Homes');
+  assert.equal(this.get('selected'), 'Sherlock Homes');
 });
 
 test('it renders from an object array', function(assert) {
@@ -35,7 +35,7 @@ test('it renders from an object array', function(assert) {
   ]);
 
   this.render(hbs`
-    {{#ui-dropdown value=value}}
+    {{#ui-dropdown selected=selected}}
       <div class='menu'>
       {{#each people as |person|}}
         <div class='item' data-value={{person.id}}>{{person.name}}</div>
@@ -45,10 +45,10 @@ test('it renders from an object array', function(assert) {
   `);
 
   assert.equal(this.$('.item').length, 2);
-  assert.equal(this.get('value'), undefined);
+  assert.equal(this.get('selected'), undefined);
 
   this.$(".menu .item[data-value=1]").click();
-  assert.equal(this.get('value'), 1);
+  assert.equal(this.get('selected'), 1);
 });
 
 test('it renders with an option selected', function(assert) {
@@ -59,9 +59,9 @@ test('it renders with an option selected', function(assert) {
     { id: 2, name: "Patrick Bateman" }
   ]);
 
-  this.set('value', 2);
+  this.set('selected', 2);
   this.render(hbs`
-    {{#ui-dropdown value=value}}
+    {{#ui-dropdown selected=selected}}
       <div class='menu'>
       {{#each people as |person|}}
         <div class='item' data-value={{person.id}}>{{person.name}}</div>
@@ -71,10 +71,10 @@ test('it renders with an option selected', function(assert) {
   `);
 
   assert.equal(this.$('.item').length, 2);
-  assert.equal(this.get('value'), 2);
+  assert.equal(this.get('selected'), 2);
 
   this.$(".menu .item[data-value=1]").click();
-  assert.equal(this.get('value'), 1);
+  assert.equal(this.get('selected'), 1);
 });
 
 test('it renders multiple', function(assert) {
@@ -86,7 +86,7 @@ test('it renders multiple', function(assert) {
   ]);
 
   this.render(hbs`
-    {{#ui-dropdown class='multiple' value=value}}
+    {{#ui-dropdown class='multiple' selected=selected}}
       <div class='menu'>
       {{#each people as |person|}}
         <div class='item' data-value={{person.id}}>{{person.name}}</div>
@@ -96,11 +96,11 @@ test('it renders multiple', function(assert) {
   `);
 
   assert.equal(this.$('.item').length, 2);
-  assert.equal(this.get('value'), undefined);
+  assert.equal(this.get('selected'), undefined);
 
   this.$(".menu .item[data-value=1]").click();
   this.$(".menu .item[data-value=2]").click();
-  assert.equal(this.get('value'), '1,2');
+  assert.equal(this.get('selected'), '1,2');
 });
 
 test('it binds to an object', function(assert) {
@@ -112,7 +112,7 @@ test('it binds to an object', function(assert) {
   ]);
 
   this.render(hbs`
-    {{#ui-dropdown value=value}}
+    {{#ui-dropdown selected=selected}}
       <div class='menu'>
       {{#each people as |person|}}
         {{#ui-dropdown-item content=person}}
@@ -124,10 +124,10 @@ test('it binds to an object', function(assert) {
   `);
 
   assert.equal(this.$('.item').length, 2);
-  assert.equal(this.get('value'), undefined);
+  assert.equal(this.get('selected'), undefined);
 
   this.$(".menu .item")[1].click();
-  assert.equal(this.get('value'), this.get('people')[1]);
+  assert.equal(this.get('selected'), this.get('people')[1]);
 });
 
 test('it sets the value from the binding', function(assert) {
@@ -140,7 +140,7 @@ test('it sets the value from the binding', function(assert) {
   ]);
 
   this.render(hbs`
-    {{#ui-dropdown value=people_id}}
+    {{#ui-dropdown selected=people_id}}
       <div class='menu'>
       {{#each people as |person|}}
         <div class="item" data-value="{{person.id}}">
@@ -181,4 +181,62 @@ test('it updates the value if updated from the binding', function(assert) {
 
   this.set('people_id', 1);
   assert.equal(this.$('.item.selected').data('value'), 1);
+});
+
+test('it can set the selected value without binding for full DDAU', function(assert) {
+  assert.expect(3);
+
+  this.set('people_id', 2);
+  this.set('people', [
+    { id: 1, name: "Sherlock Homes" },
+    { id: 2, name: "Patrick Bateman" }
+  ]);
+
+  this.on('update', function(value) {
+    this.set('people_id', value);
+  });
+
+  this.render(hbs`
+    {{#ui-dropdown onChange=(action 'update')}}
+      <input type="hidden" name="person" value="{{people_id}}" />
+      <div class='menu'>
+      {{#each people as |person|}}
+        <div class="item" data-value="{{person.id}}">
+          {{person.name}}
+        </div>
+      {{/each}}
+      </div>
+    {{/ui-dropdown}}
+  `);
+
+  assert.equal(this.$('.item').length, 2);
+  assert.equal(this.$('.item.selected').data('value'), 2);
+
+  $(this.$('.item')[0]).click();
+  assert.equal(this.$('.item.selected').data('value'), 1);
+});
+
+test('value binding should set the value as well', function(assert) {
+  assert.expect(2);
+
+  // this.set('people_id', 2);
+  this.set('people', [
+    { id: 1, name: "Sherlock Homes" },
+    { id: 2, name: "Patrick Bateman" }
+  ]);
+
+  this.render(hbs`
+    {{#ui-dropdown value=2}}
+      <div class='menu'>
+      {{#each people as |person|}}
+        <div class="item" data-value="{{person.id}}">
+          {{person.name}}
+        </div>
+      {{/each}}
+      </div>
+    {{/ui-dropdown}}
+  `);
+
+  assert.equal(this.$('.item').length, 2);
+  assert.equal(this.$('.item.selected').text(), "Patrick Bateman");
 });

--- a/tests/integration/components/ui-dropdown-test.js
+++ b/tests/integration/components/ui-dropdown-test.js
@@ -131,7 +131,7 @@ test('it binds to an object', function(assert) {
 });
 
 test('it sets the value from the binding', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   this.set('people_id', 2);
   this.set('people', [
@@ -153,4 +153,32 @@ test('it sets the value from the binding', function(assert) {
 
   assert.equal(this.$('.item').length, 2);
   assert.equal(this.$('.item.selected').length, 1);
+  assert.equal(this.$('.item.selected').data('value'), 2);
+});
+
+test('it updates the value if updated from the binding', function(assert) {
+  assert.expect(2);
+
+  this.set('people_id', 2);
+  this.set('people', [
+    { id: 1, name: "Sherlock Homes" },
+    { id: 2, name: "Patrick Bateman" }
+  ]);
+
+  this.render(hbs`
+    {{#ui-dropdown selected=people_id}}
+      <div class='menu'>
+      {{#each people as |person|}}
+        <div class="item" data-value="{{person.id}}">
+          {{person.name}}
+        </div>
+      {{/each}}
+      </div>
+    {{/ui-dropdown}}
+  `);
+
+  assert.equal(this.$('.item').length, 2);
+
+  this.set('people_id', 1);
+  assert.equal(this.$('.item.selected').data('value'), 1);
 });


### PR DESCRIPTION
This is a minor logic change for dropdown. If you bind to value it will call `set value` on initialize and if you bind to selected it will call `set selected` on initialize. The logic within *Semantic-UI* indicates that setting a value updates the value but doesn't refresh the UI and setting selected updates both.

- Updated dropdown so it sets both "selected" and "value" depending on what was passed into the component
- Removed the initial element set, not sure if this is needed anymore it was a pretty old and we don't have a test that indicates an issue
