### PR TITLE
Added "checkbox" module to not auto-update its properties (fixes #69)

### DIFF
--- a/addon/mixins/base.js
+++ b/addon/mixins/base.js
@@ -89,7 +89,7 @@ Semantic.BaseMixin = Ember.Mixin.create({
     var _this = this;
     var properties = {};
     // Modules without setable properties
-    if (['accordion', 'nag'].indexOf(this.get('module')) === -1) {
+    if (['accordion', 'nag', 'checkbox'].indexOf(this.get('module')) === -1) {
       properties = this.execute('set');
     }
     var property;


### PR DESCRIPTION
Auto-updating properties (i.e. "set checked") seems to not be doing anything for "ui-radio" or "ui-checkbox" components, except it breaks radio-buttons on certain configurations (see issue #69 ). If you add "checkbox" to the list of excluded modules (as in this PR), it works as intended again.