### PR TITLE
removing error from ignored properties to use in the setting of the modules

### DIFF
--- a/addon/mixins/base.js
+++ b/addon/mixins/base.js
@@ -3,7 +3,7 @@ import Semantic from '../semantic';
 
 // Static properties to ignore
 const DEBUG = ['debug', 'performance', 'verbose'];
-const STANDARD = ['name', 'namespace', 'className', 'error', 'metadata', 'selector'];
+const STANDARD = ['name', 'namespace', 'className', 'metadata', 'selector'];
 const EMBER = ['context', 'on', 'template', 'execute'];
 
 


### PR DESCRIPTION
When trying to use `error` property in some modules like the `ui-search` it gets ignored
Since this prop is ignored we can't override these configs, like error messages

```
// component.js
error: {
  noResults: 'foo bar'
}

// template.hbs
{{ ui-search error=error }}
```