### PR TITLE
Should Run Before SRI Integrity Generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "ember-cli-babel": "^5.1.3"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "before": "ember-cli-sri"
   }
 }


### PR DESCRIPTION
If this plugin runs CSS & JS generation after ember-cli-sri has run, the running app will fail to find a valid digest in the `integrity` attribute for the resource.

It seems to be similar to this: https://github.com/ember-cli/ember-cli/issues/5040 and this issue in [ember-paper](https://github.com/miguelcobain/ember-paper/issues/224)

It seems to be an issue in Chrome only. No problem when using Firefox.