### PR TITLE
Deprecation warning for ui-dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ There isn't a corresponding Ember component for this since it isn't rendered to 
  * **Class**: `ui dropdown`
  * **Component**: `ui-dropdown`
  * **Parameters**
-    * **value**: Bound value that is set to `optionValuePath` (deprecated, bind to selected on ui-dropdown instead of value as semantic doesn't update the display when the value is set)
     * **selected**: Bound value that is set to `optionValuePath`
     * **onChange**: Event to bind changes too
    

--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ There isn't a corresponding Ember component for this since it isn't rendered to 
  * **Class**: `ui dropdown`
  * **Component**: `ui-dropdown`
  * **Parameters**
-    * **value**: Bound value that is set to `optionValuePath`
+    * **value**: Bound value that is set to `optionValuePath` (deprecated, bind to selected on ui-dropdown instead of value as semantic doesn't update the display when the value is set)
+    * **selected**: Bound value that is set to `optionValuePath`
     * **onChange**: Event to bind changes too
    
 Replace `<div class="ui dropdown">` with `{{ui-dropdown}}` and fill in your content


### PR DESCRIPTION
Hi. I've used this semantic-ui binding and found that README.md isn't up to date. Binding to ui-dropdown `value` property produces runtime deprecation warning that suggests to bind `selected` property instead, so I updated README.md according to this warning.