### PR TITLE
Added the cssPath option to manage where the theme files will be installed

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,13 +39,25 @@ module.exports = {
     }
 
     if (getWithDefault(options['images'], defaults['images'])) {
-      var imageOptions = { destDir: 'assets/themes/default/assets/images' };
+      var imageOptions;
+      if (options["cssPath"] && options["cssPath"] !== null) {
+        imageOptions = { destDir: options.cssPath + '/themes/default/assets/images' };
+      }
+      else {
+        imageOptions = { destDir: 'assets/themes/default/assets/images' };
+      }
       app.import('bower_components/semantic-ui/dist/themes/default/assets/images/flags.png', imageOptions);
     }
 
     if (getWithDefault(options['fonts'], defaults['fonts'])) {
       var fontExtensions = ['.eot','.otf','.svg','.ttf','.woff','.woff2'];
-      var fontOptions = { destDir: 'assets/themes/default/assets/fonts' };
+      var fontOptions;
+      if (options["cssPath"] && options["cssPath"] !== null) {
+        fontOptions = { destDir: options.cssPath + '/themes/default/assets/fonts' };
+      }
+      else {
+        fontOptions = { destDir: 'assets/themes/default/assets/fonts' };
+      }
       for (var i = fontExtensions.length - 1; i >= 0; i--) {
         app.import('bower_components/semantic-ui/dist/themes/default/assets/fonts/icons'+fontExtensions[i], fontOptions);
       };


### PR DESCRIPTION
Fixes #104.

By default, SemanticUI expects the fonts and images path (`themes/default/assets/(images | fonts)`) to be on the same path as the output css file (`dist/assets/`). If the user or any module changes the default directory for css files (e.g. css files are copied to `dist/assets/css/`), the application will not be able to load fonts and images.

Adding the cssPath option allows the app to adjust the output directory of fonts and images to be on the same level as the output css files. For example:

```js
module.exports = function ( defaults ) {
  const app = new EmberApp( defaults, {
    // Add options here
    outputPaths: {
      app: {
        css: {
          app: "/assets/css/ember-webapp.css",
        },
        js: "/assets/js/ember-webapp.js",
      },

      vendor: {
        css: "/assets/css/vendor.css",
        js: "/assets/js/vendor.js",
      },
    },
    SemanticUI: {
      cssPath: "/assets/css",
    },
  } );
```

This would output the fonts and images to `dist/assets/css/themes/default/assets/(images | fonts)` and will be found by SemanticUI css file when importing fonts and images.