### PR TITLE
Added sticky to README and sorted it in alphabetical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,37 +106,6 @@ export default Ember.Controller.extend({
 {{ui-checkbox checked=havingFun}}
 ```
 
-## Radio
-
-* **Class**: `ui radio`
-* **Component**: `ui-radio`
-
-Replace `<div class="ui radio">` with `{{ui-radio}}` and bind to a property on your model/controller/component.
-
-### Controller
-```javascript
-export default Ember.Controller.extend({
-  fruit: null
-});
-```
-
-### Template
-```handlebars
-<div class="ui form">
-  <div class="grouped inline fields">
-    <div class="field">
-      {{ui-radio name="fruit" label="Once a week" value="apple" current=fruit}}
-    </div>
-    <div class="field">
-      {{ui-radio name="fruit" label="2-3 times a week" value="orange" current=fruit}}
-    </div>
-    <div class="field">
-      {{ui-radio name="fruit" label="Once a day" value="grape" current=fruit}}
-    </div>
-  </div>
-</div>
-```
-
 ## Dimmer
 
  * **Documentation**: [Official Documentation](http://semantic-ui.com/modules/dimmer.html)
@@ -299,6 +268,37 @@ You can also create an icon version by specifying the tagName
   <div class="bar"></div>
   <div class="label">Completed</div>
 {{/ui-progress}}
+```
+
+## Radio
+
+* **Class**: `ui radio`
+* **Component**: `ui-radio`
+
+Replace `<div class="ui radio">` with `{{ui-radio}}` and bind to a property on your model/controller/component.
+
+### Controller
+```javascript
+export default Ember.Controller.extend({
+  fruit: null
+});
+```
+
+### Template
+```handlebars
+<div class="ui form">
+  <div class="grouped inline fields">
+    <div class="field">
+      {{ui-radio name="fruit" label="Once a week" value="apple" current=fruit}}
+    </div>
+    <div class="field">
+      {{ui-radio name="fruit" label="2-3 times a week" value="orange" current=fruit}}
+    </div>
+    <div class="field">
+      {{ui-radio name="fruit" label="Once a day" value="grape" current=fruit}}
+    </div>
+  </div>
+</div>
 ```
 
 ## Rating

--- a/README.md
+++ b/README.md
@@ -421,6 +421,25 @@ export default Ember.Controller.extend(Ember.Evented, {
 });
 ```
 
+## Sticky
+
+ * **Documentation**: [Official Documentation](http://semantic-ui.com/modules/sticky.html)
+ * **Class**: `ui sticky`
+
+### Template
+```handlebars
+{{#ui-sticky}}
+  <div class="ui three item menu">
+    <a class="active item">Editorials</a>
+    <a class="item">Reviews</a>
+    <a class="item">Upcoming Events</a>
+  </div>
+{{/ui-sticky}}
+<div>
+<!-- Any arbitary content -->
+</div>
+```
+
 ## Tab
 
 Not implemented. Better suited to use routes through Ember. If you disagree please open an issue with how you would see it used.


### PR DESCRIPTION
Hi all, I think this ember add-on is useful and handy even for beginners in ember.js (like me), but when I started picking up this add-on, I found that the doc need a little improvement as I did not know there is sticky component available until I read into code. 

So in this pull request I did two small changes:
1. Re-arranged the order of component description by alphabetical order
2. Added the description of sticky (!)

Regards,
Pui Yiu