### PR TITLE
Fix Enumerable#contains deprecation warnings

### DIFF
--- a/addon/mixins/base.js
+++ b/addon/mixins/base.js
@@ -35,9 +35,9 @@ Semantic.BaseMixin = Ember.Mixin.create({
 
     for (let key in this.get('attrs')) {
       // If it has a settable and gettable attribute, then its bindable
-      if (settableProperties.contains(key) && gettableProperties.contains(key)) {
+      if (settableProperties.includes(key) && gettableProperties.includes(key)) {
         this.get('_bindableAttrs').addObject(key);
-      } else if (settableProperties.contains(key)) {
+      } else if (settableProperties.includes(key)) {
         // otherwise, its settable only
         this.get('_settableAttrs').addObject(key);
       }
@@ -191,7 +191,7 @@ Semantic.BaseMixin = Ember.Mixin.create({
       let value = this._getAttrValue(key);
 
       if (!moduleGlobal.settings.hasOwnProperty(key)) {
-        if (!this.get('_ignorableAttrs').contains(key) && !this.get('_ignorableAttrs').contains(Ember.String.camelize(key))) {
+        if (!this.get('_ignorableAttrs').includes(key) && !this.get('_ignorableAttrs').includes(Ember.String.camelize(key))) {
           // TODO: Add better ember keys here
           Ember.Logger.debug(`You passed in the property '${key}', but a setting doesn't exist on the Semantic UI module: ${moduleName}`);
         }
@@ -248,7 +248,7 @@ Semantic.BaseMixin = Ember.Mixin.create({
   },
 
   _swapAttrs(attrName) {
-    if (this.get('_settableAttrs').contains(attrName)) {
+    if (this.get('_settableAttrs').includes(attrName)) {
       this.get('_settableAttrs').removeObject(attrName);
       this.get('_bindableAttrs').addObject(attrName);
     }


### PR DESCRIPTION
As of ember 2.8.0-beta.1, `Enumerable.contains()` has been depreciated in favor of `Enumerable.includes()`. Semantic-UI-Ember uses the depreciated function in several places, this simply replaces those usages. http://emberjs.com/deprecations/v2.x/#toc_enumerable-contains