### PR TITLE
Allow custom semantic-ui builds

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,6 +7,11 @@ module.exports = function(defaults) {
     // Add options here
     babel: {
       includePolyfill: false
+    },
+    SemanticUI: {
+      paths: {
+        fonts: 'assets/themes/default/assets/fonts',
+      }
     }
   });
 
@@ -16,9 +21,6 @@ module.exports = function(defaults) {
     This build file does *not* influence how the addon or the app using it
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
-
-  app.import('bower_components/semantic-ui/dist/semantic.css');
-  app.import('bower_components/semantic-ui/dist/semantic.js');
 
   // Import Highlight.js
   app.import(app.bowerDirectory + "/highlightjs/highlight.pack.min.js");

--- a/index.js
+++ b/index.js
@@ -2,51 +2,57 @@
 'use strict';
 
 var defaults = {
-  css: true,
-  javascript: true,
-  fonts: true,
-  images: true
-};
-
-var getWithDefault = function(property, default_property) {
-  if (property === null || property === undefined) {
-    return default_property;
+  imports: {
+    css: true,
+    javascript: true,
+    fonts: true,
+    images: true,
+  },
+  paths: {
+    theme: 'default',
+    source: 'bower_components/semantic-ui/dist',
   }
-
-  return property;
 };
+
+var generation = require('./utils/generation');
 
 module.exports = {
   name: 'semantic-ui-ember',
 
   included: function (app) {
     var options = (app && app.options['SemanticUI']) || {};
+    var path = generation.default('paths', 'source', [options, defaults]);
+    var theme = generation.default('paths', 'theme', [options, defaults]);
+    var css = generation.default('imports', 'css', [options, defaults]);
+    var javascript = generation.default('imports', 'javascript', [options, defaults]);
+    var fonts = generation.default('imports', 'fonts', [options, defaults]);
+    var images = generation.default('imports', 'images', [options, defaults]);
 
-    if (getWithDefault(options['css'], defaults['css'])) {
+    if (css) {
       app.import({
-        development: 'bower_components/semantic-ui/dist/semantic.css',
-        production: 'bower_components/semantic-ui/dist/semantic.min.css'
+        development: generation.format(path, 'semantic.css'),
+        production: generation.format(path, 'semantic.min.css')
       });
     }
 
-    if (getWithDefault(options['javascript'], defaults['javascript'])) {
+    if (javascript) {
       app.import({
-        development: 'bower_components/semantic-ui/dist/semantic.js',
-        production: 'bower_components/semantic-ui/dist/semantic.min.js'
+        development: generation.format(path, 'semantic.js'),
+        production: generation.format(path, 'semantic.min.js')
       });
     }
 
-    if (getWithDefault(options['images'], defaults['images'])) {
-      var imageOptions = { destDir: 'assets/themes/default/assets/images' };
-      app.import('bower_components/semantic-ui/dist/themes/default/assets/images/flags.png', imageOptions);
+    if (images) {
+      var imageOptions = { destDir: generation.format(path, theme, 'assets/images')};
+      app.import(generation.format(path, 'themes', theme, 'assets/images/flags.png'), imageOptions);
     }
 
-    if (getWithDefault(options['fonts'], defaults['fonts'])) {
+    if (fonts) {
       var fontExtensions = ['.eot','.otf','.svg','.ttf','.woff','.woff2'];
-      var fontOptions = { destDir: 'assets/themes/default/assets/fonts' };
+      var fontOptions = { destDir: 'assets/fonts' };
       for (var i = fontExtensions.length - 1; i >= 0; i--) {
-        app.import('bower_components/semantic-ui/dist/themes/default/assets/fonts/icons'+fontExtensions[i], fontOptions);
-      };
+        app.import(generation.format(path, 'themes', theme, 'assets/fonts/icons')+fontExtensions[i], fontOptions);
+      }
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var defaults = {
   paths: {
     theme: 'default',
     source: 'bower_components/semantic-ui/dist',
+    fonts: 'assets/fonts',
   }
 };
 
@@ -49,7 +50,8 @@ module.exports = {
 
     if (fonts) {
       var fontExtensions = ['.eot','.otf','.svg','.ttf','.woff','.woff2'];
-      var fontOptions = { destDir: 'assets/fonts' };
+      var fontDestinationDir = generation.default('paths', 'fonts', [options, defaults]);
+      var fontOptions = { destDir: fontDestinationDir };
       for (var i = fontExtensions.length - 1; i >= 0; i--) {
         app.import(generation.format(path, 'themes', theme, 'assets/fonts/icons')+fontExtensions[i], fontOptions);
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.2.2",
-    "loader.js": "^4.0.1"
+    "loader.js": "^4.0.1",
+    "tape": "^4.6.0"
   },
   "keywords": [
     "ember-addon"

--- a/utils/build-tests.js
+++ b/utils/build-tests.js
@@ -20,6 +20,7 @@ var defaults = function() {
     paths: {
       'source': 'bower_components/semantic-ui/dist',
       'theme': 'default',
+      'fonts': 'assets/fonts',
     }
   };
 };
@@ -38,6 +39,11 @@ test('use the user option path of the theme if in the options', function (t) {
   t.equal(generate.default('paths', 'theme', [{'paths': {'theme': ''}}, defaults()]), '');
   t.equal(generate.default('paths', 'theme', [{'paths': {'theme': null}}, defaults()]), null);
   t.equal(generate.default('paths', 'theme', [{'paths': {}}, defaults()]), 'default');
+});
+
+test('can change the font destination directory', function (t) {
+  t.plan(1);
+  t.equal(generate.default('paths', 'fonts', [{'paths': {'fonts': 'assets/themes/material/assets/fonts/'}}, defaults()]), 'assets/themes/material/assets/fonts/');
 });
 
 test('use new default location of imports', function (t) {

--- a/utils/build-tests.js
+++ b/utils/build-tests.js
@@ -50,6 +50,11 @@ test('use new location of imports', function (t) {
   t.equal(generate.default('imports', 'fonts', [{'imports': {'fonts': false}}, defaults()]), false);
 });
 
+test('use new location of imports if undefined in user options', function (t) {
+  t.plan(1);
+  t.equal(generate.default('imports', 'javascript', [{'imports': {'fonts': false}}, defaults()]), true);
+});
+
 test('use old default location of imports', function (t) {
   t.plan(1);
   t.equal(generate.default('imports', 'fonts', [oldDefaults, defaults()]), false);

--- a/utils/build-tests.js
+++ b/utils/build-tests.js
@@ -1,0 +1,65 @@
+/* jshint node: true */
+var test = require('tape');
+var generate = require('./generation');
+
+var oldDefaults = {
+  css: true,
+  javascript: true,
+  fonts: false,
+  images: true,
+};
+
+var defaults = function() {
+  return {
+    imports: {
+      css: true,
+      javascript: true,
+      fonts: true,
+      images: true,
+    },
+    paths: {
+      'source': 'bower_components/semantic-ui/dist',
+      'theme': 'default',
+    }
+  };
+};
+
+test('use the default path of the theme if not in the options', function (t) {
+  t.plan(4);
+  t.equal(generate.default('paths', 'theme', [{}, defaults()]), 'default');
+  t.equal(generate.default('paths', 'theme', [null, defaults()]), 'default');
+  t.equal(generate.default('paths', 'theme', [undefined, defaults()]), 'default');
+  t.equal(generate.default('paths', 'theme', [{'fonts': true}, defaults()]), 'default');
+});
+
+test('use the user option path of the theme if in the options', function (t) {
+  t.plan(4);
+  t.equal(generate.default('paths', 'theme', [{'paths': {'theme': 'boston'}}, defaults()]), 'boston');
+  t.equal(generate.default('paths', 'theme', [{'paths': {'theme': ''}}, defaults()]), '');
+  t.equal(generate.default('paths', 'theme', [{'paths': {'theme': null}}, defaults()]), null);
+  t.equal(generate.default('paths', 'theme', [{'paths': {}}, defaults()]), 'default');
+});
+
+test('use new default location of imports', function (t) {
+  t.plan(1);
+  t.equal(generate.default('imports', 'fonts', [{}, defaults()]), true);
+});
+
+test('use new location of imports', function (t) {
+  t.plan(1);
+  t.equal(generate.default('imports', 'fonts', [{'imports': {'fonts': false}}, defaults()]), false);
+});
+
+test('use old default location of imports', function (t) {
+  t.plan(1);
+  t.equal(generate.default('imports', 'fonts', [oldDefaults, defaults()]), false);
+});
+
+
+test('format removes null, undefined, and whitespace values', function (t) {
+  t.plan(4);
+  t.equal(generate.format('j', 1, 'a b', '/'), 'j/1/a b//');
+  t.equal(generate.format(null, 1, 'a b', '/'), '1/a b//');
+  t.equal(generate.format(null, 1, 'a b', undefined), '1/a b');
+  t.equal(generate.format(null, 1, 'a b', undefined, 'couldItBe', '    '), '1/a b/couldItBe');
+});

--- a/utils/generation.js
+++ b/utils/generation.js
@@ -1,0 +1,45 @@
+/* jshint node: true */
+'use strict';
+
+function isObject(obj) {
+    if (obj === null) { return false; }
+    return Object.keys(obj).length === 0 && obj.constructor === Object;
+}
+
+function isObjectWithKeys(obj) {
+    if (obj === null) { return false; }
+    return Object.keys(obj).length > 0 && obj.constructor === Object;
+}
+
+function extend(obj, src) {
+  Object.keys(src).forEach(function(key) {
+    if (isObjectWithKeys(src[key])) {
+      obj[key] = extend(obj[key], src[key]);
+    }
+    if (src[key] !== undefined && !isObject(src[key])) {
+      obj[key] = src[key];
+    }
+  });
+  return obj;
+}
+
+function oldDefaults(userOptions) {
+  return userOptions['javascript'] || userOptions['css'] || userOptions['fonts'] || userOptions['images'];
+}
+
+var exports = module.exports = {};
+
+exports.default = function(path, property, options) {
+  var userOptions = options[0] || {};
+  var opts = extend(options[1], userOptions);
+  var old = oldDefaults(userOptions);
+  if (old && path === 'imports') {
+    return opts[property];
+  }
+  return opts[path][property];
+};
+
+exports.format = function() {
+  var args = Array.prototype.slice.call(arguments);
+  return args.filter(Boolean).filter(function(e) { return (typeof e === 'string') ? !e.match(/^\s+$/) : e; }).join('/');
+};

--- a/utils/generation.js
+++ b/utils/generation.js
@@ -3,7 +3,7 @@
 
 function isObject(obj) {
     if (obj === null) { return false; }
-    return Object.keys(obj).length === 0 && obj.constructor === Object;
+    return Object.keys(obj).length >= 0 && obj.constructor === Object;
 }
 
 function isObjectWithKeys(obj) {


### PR DESCRIPTION
Adds two configuration options. One for the path to the `dist` folder of
Semantic. The other option to specify the theme used for images and
fonts.

Note that this does not add support for importing files outside of the
build tree (e.g. `bower_components`). One can use `bower link` for local
projects.