### PR TITLE
Move ember-string-ishtmlsafe-polyfill to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "ember-string-ishtmlsafe-polyfill": "1.0.1",
     "ember-try": "^0.2.2",
     "loader.js": "^4.0.1",
     "tape": "^4.6.0"
@@ -68,7 +67,8 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-promise-tools": "1.0.0",
-    "ember-runtime-enumerable-includes-polyfill": "^1.0.1"
+    "ember-runtime-enumerable-includes-polyfill": "^1.0.1",
+    "ember-string-ishtmlsafe-polyfill": "1.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Containing apps break when polyfill is not installed.

When installing, the polyfill is not installed, while the other polyfills are.