### PR TITLE
Update isHTMLSafe polyfill dep

### DIFF
--- a/addon/mixins/base.js
+++ b/addon/mixins/base.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import Semantic from '../semantic';
-import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 const EMBER_ATTRS = ['class', 'classNameBindings', 'classNames', 'tagName'];
 const HTML_ATTRS = ['id', 'name', 'readonly', 'autofocus', 'tabindex', 'title'];
@@ -220,7 +219,7 @@ Semantic.BaseMixin = Ember.Mixin.create({
         custom[key] = Ember.run.bind(this, this._updateFunctionWithParameters(key, value));
       }
       if (typeof value === 'object') {
-        if (isHTMLSafe(value)) {
+        if (Ember.String.isHTMLSafe(value)) {
           custom[key] = this._unwrapHTMLSafe(value);
         }
       }
@@ -269,7 +268,7 @@ Semantic.BaseMixin = Ember.Mixin.create({
   },
 
   _unwrapHTMLSafe(value) {
-    if (isHTMLSafe(value)) {
+    if (Ember.String.isHTMLSafe(value)) {
       return value.toString();
     }
     return value;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-promise-tools": "1.0.0",
     "ember-runtime-enumerable-includes-polyfill": "^1.0.1",
-    "ember-string-ishtmlsafe-polyfill": "1.0.1"
+    "ember-string-ishtmlsafe-polyfill": "^1.1.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
Latest release places the polyfill in the “native” location, instead of needing to import the function.

Note: This is part of an effort to get all users of the polyfill updated.. https://github.com/workmanw/ember-string-ishtmlsafe-polyfill/issues/5