### PR TITLE
Add code snippet

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "semantic-ui-ember",
   "dependencies": {
-    "highlightjs": "^9.4.0",
     "semantic-ui": "2.2.11"
   }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -18,9 +18,6 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  // Import Highlight.js
-  app.import(app.bowerDirectory + "/highlightjs/highlight.pack.min.js");
-
   app.import(app.bowerDirectory + "/highlightjs/styles/github-gist.css");
   app.import(app.bowerDirectory + "/highlightjs/styles/hybrid.css");
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,7 +7,8 @@ module.exports = function(defaults) {
     // Add options here
     'ember-cli-babel': {
       includePolyfill: false
-    }
+    },
+    snippetSearchPaths: ['tests/dummy/app']
   });
 
   /*

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-code-snippet": "^1.9.0",
     "ember-composable-helpers": "2.0.3",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "2.0.0",

--- a/tests/dummy/app/components/ui-code-snippet.js
+++ b/tests/dummy/app/components/ui-code-snippet.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: ['annotation', 'transition'],
+  classNameBindings: ['showing:visible:hidden']
+});

--- a/tests/dummy/app/templates/components/ui-code-snippet.hbs
+++ b/tests/dummy/app/templates/components/ui-code-snippet.hbs
@@ -1,0 +1,3 @@
+<div class="ui instructive bottom attached segment">
+  {{code-snippet name=name}}
+</div>

--- a/tests/dummy/app/templates/modules/sidebar.hbs
+++ b/tests/dummy/app/templates/modules/sidebar.hbs
@@ -17,14 +17,13 @@
       <p>
         For additional documentation on how to configure this module, please refer to the {{#link-to 'modules.index'}}Getting Started{{/link-to}} section and Semantic UI's module specific external documentation links below.
       </p>
-      {{! BEGIN-SNIPPET sidebar2.example }}
+
       <div class="ui four item stackable tabs menu">
         <a class="item" href="http://semantic-ui.com/modules/sidebar.html" target="_blank">Definition</a>
         <a class="item" href="http://semantic-ui.com/modules/sidebar.html#/examples" target="_blank">Examples</a>
         <a class="item" href="http://semantic-ui.com/modules/sidebar.html#/usage" target="_blank">Usage</a>
         <a class="item" href="http://semantic-ui.com/modules/sidebar.html#/settings" target="_blank">Settings</a>
       </div>
-      {{! END-SNIPPET }}
 
     </div>
 

--- a/tests/dummy/app/templates/modules/sidebar.hbs
+++ b/tests/dummy/app/templates/modules/sidebar.hbs
@@ -1,3 +1,5 @@
+
+
 <div class="ui masthead vertical segment">
   <div class="ui container">
     <div class="introduction">
@@ -15,13 +17,14 @@
       <p>
         For additional documentation on how to configure this module, please refer to the {{#link-to 'modules.index'}}Getting Started{{/link-to}} section and Semantic UI's module specific external documentation links below.
       </p>
-
+      {{! BEGIN-SNIPPET sidebar2.example }}
       <div class="ui four item stackable tabs menu">
         <a class="item" href="http://semantic-ui.com/modules/sidebar.html" target="_blank">Definition</a>
         <a class="item" href="http://semantic-ui.com/modules/sidebar.html#/examples" target="_blank">Examples</a>
         <a class="item" href="http://semantic-ui.com/modules/sidebar.html#/usage" target="_blank">Usage</a>
         <a class="item" href="http://semantic-ui.com/modules/sidebar.html#/settings" target="_blank">Settings</a>
       </div>
+      {{! END-SNIPPET }}
 
     </div>
 
@@ -35,7 +38,8 @@
     as |showing setCopyCode|}}
 
     {{#ui-html showing=showing}}
-      <div class="ui button" {{action 'toggle' 'sub-sidebar'}}>
+      {{! BEGIN-SNIPPET sidebar.example }}
+      <div class="ui button" {{action "toggle" "sub-sidebar"}}>
         Toggle
       </div>
       <div class="ui pushable segment component context">
@@ -50,26 +54,10 @@
           </div>
         </div>
       </div>
+      {{! END-SNIPPET }}
     {{/ui-html}}
 
-    {{#ui-annotation showing=showing setCopyCode=setCopyCode}}
-<div class="ui button" onclick="\{{action 'toggle' 'sub-sidebar'}}">
-  Toggle
-</div>
-<div class="ui pushable segment component context">
-  \{{#ui-sidebar class="inverted menu left inline vertical" context=".component.context" id="sub-sidebar"}}
-    <a class="item">Item 1</a>
-    <a class="item">Item 2</a>
-    <a class="item">Item 3</a>
-  \{{/ui-sidebar}}
-  <div class="pusher">
-    <div class="ui basic segment" style="min-height: 300px;">
-      Sub Content Here
-    </div>
-  </div>
-</div>
-    {{/ui-annotation}}
-
+    {{ui-code-snippet showing=showing name="sidebar.example.hbs"}}
   {{/ui-example}}
 
 </div>


### PR DESCRIPTION
This is a proposal to change the way we get the code snippet in the documentation.

## What this solves?
- Resolving a snippet problem is not valid
- Solve the problem of updating the example and do not remember to update the snippet
- Possibility of catching snippet of controller, component, route

This project also use it.

https://github.com/miguelcobain/ember-paper
https://github.com/ef4/ember-code-snippet

If they agree, I can replicate it for all the documentation. 