### PR TITLE
Solve bug ui-source (#181)

### DIFF
--- a/addon/components/ui-search.js
+++ b/addon/components/ui-search.js
@@ -3,5 +3,24 @@ import Base from '../mixins/base';
 
 export default Ember.Component.extend(Base, {
   module: 'search',
-  classNames: ['ui', 'search']
+  classNames: ['ui', 'search'],
+
+  didInitSemantic(...args) {
+    this._super(...args);
+    this.get('_bindableAttrs').addObject('source');
+  },
+  execute(...args){
+    const cmd = args[0];
+    const attrValue = args[1];
+
+    if(cmd === 'set source') {
+      let module = this.getSemanticModule();
+      if (module) {
+        return module.apply(this.getSemanticScope(), [{
+          source: attrValue
+        }]);
+      }
+    }
+    return this._super(...args);
+  }
 });


### PR DESCRIPTION
I did not like the solution. I'm accepting suggestions.

## Problem

API `object.search('set source', []);` don't working :confused: 

Fix: https://github.com/Semantic-Org/Semantic-UI-Ember/issues/181

Simulation: https://ember-twiddle.com/56f28ca7aecd9e6fc17b824a900596e3