### PR TITLE
Sidebar example typo

### DIFF
--- a/tests/dummy/app/templates/modules/sidebar.hbs
+++ b/tests/dummy/app/templates/modules/sidebar.hbs
@@ -53,7 +53,7 @@
     {{/ui-html}}
 
     {{#ui-annotation showing=showing setCopyCode=setCopyCode}}
-<div class="ui button" onclick="\{{action 'toggle' 'sub-sidebar'}}">
+<div class="ui button" onclick=\{{action 'toggle' 'sub-sidebar'}}>
   Toggle
 </div>
 <div class="ui pushable segment component context">


### PR DESCRIPTION
- Action in sidebar example is passed correctly as an action and not as a string.