### PR TITLE
Resolve issue with resolving configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = {
     if (typeof this._findHost === 'function') {
       app = this._findHost();
     }
-    const options = (app && app.options['SemanticUI']) || {};
+    const options = (app && app.options['SemanticUI']) || (app && app.options['semantic-ui-ember']) || {};
 
     if (!fs.existsSync(defaults.source.css) && fs.existsSync(custom.source.css)) {
       defaults.source = custom.source

--- a/index.js
+++ b/index.js
@@ -47,9 +47,7 @@ module.exports = {
     if (typeof this._findHost === 'function') {
       app = this._findHost();
     }
-    const options = (app && app.project.config(app.env)['SemanticUI'])
-      || (app && app.project.config(app.env)['semantic-ui-ember'])
-      || {};
+    const options = (app && app.options['SemanticUI']) || {};
 
     if (!fs.existsSync(defaults.source.css) && fs.existsSync(custom.source.css)) {
       defaults.source = custom.source


### PR DESCRIPTION
See #231 for additional information. Beware that I've removed the following config resolvers:

```
(app && app.project.config(app.env)['SemanticUI'])
|| (app && app.project.config(app.env)['semantic-ui-ember'])
```

I don't know what these do and where they get their config from. The change proposed in this PR reflects the actual documentation and has been tested on ember-cli 3.0.