### PR TITLE
Copy all icon fonts assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 
 const path = require('path')
 const fs = require('fs')
+const walkSync = require('walk-sync')
 
 const defaults = {
   import: {
@@ -82,11 +83,12 @@ module.exports = {
 
     const importFonts = getDefault('import', 'fonts', [options, defaults])
     if (importFonts) {
-      const fontExtensions = ['.eot', '.otf', '.svg', '.ttf', '.woff', '.woff2']
       const sourceFont = getDefault('source', 'fonts', [options, defaults])
       const fontOptions = {destDir: getDefault('destination', 'fonts', [options, defaults])}
-      for (let i = fontExtensions.length - 1; i >= 0; i--) {
-        app.import(path.join(sourceFont, 'icons' + fontExtensions[i]), fontOptions);
+      var fontFiles = walkSync(sourceFont, { directories: false });
+      var font;
+      for(font of fontFiles) {
+        app.import(path.join(sourceFont, font), fontOptions);
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "ember-try": "^0.2.23",
     "highlightjs": "^9.10.0",
     "loader.js": "^4.0.10",
-    "tape": "^4.9.0"
+    "tape": "^4.9.0",
+    "walk-sync": "^0.3.1"
   },
   "engines": {
     "node": ">= 4"


### PR DESCRIPTION
Currently only `icons.*` font files are imported, whereas semantic-ui now also ships with `outline-icons.*` and `brand-icons.*`. This PR uses `walk-sync` to find all font files in the specified directory and copies them over.