### PR TITLE
Bugfix: use addon config options #238

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,14 @@ module.exports = {
     if (typeof this._findHost === 'function') {
       app = this._findHost();
     }
-    const options = (app && app.options['SemanticUI']) || (app && app.options['semantic-ui-ember']) || {};
+    let options;
+    if (app && app.options['SemanticUI']) {
+      options = app.options['SemanticUI']
+    } else if (app && app.options['semantic-ui-ember']) {
+      options = app.options['semantic-ui-ember']
+    } else {
+      options = {}
+    }
 
     if (!fs.existsSync(defaults.source.css) && fs.existsSync(custom.source.css)) {
       defaults.source = custom.source

--- a/tape-tests/utils/get-default-test.js
+++ b/tape-tests/utils/get-default-test.js
@@ -22,6 +22,12 @@ var defaults = function() {
   };
 };
 
+let customOptions = {
+  import: {
+    css: false
+  }
+}
+
 test('use the default path of the theme if not in the options', function (assert) {
   assert.plan(4);
   assert.equal(getDefault('paths', 'theme', [{}, defaults()]), 'default');
@@ -62,4 +68,9 @@ test('use new location of imports if undefined in user options', function (asser
 test('use old default location of imports', function (assert) {
   assert.plan(1);
   assert.equal(getDefault('imports', 'fonts', [oldDefaults, defaults()]), false);
+});
+
+test('user-defined options are read', function (assert) {
+  assert.plan(1);
+  assert.equal(getDefault('import', 'css', [customOptions]), false);
 });


### PR DESCRIPTION
## What this PR does

It fixes a bug where the consuming app's options set in `ember-cli-build` were not being read by this addon.

## The problem:

The ember-cli-build.js [configuration options](http://semantic-org.github.io/Semantic-UI-Ember/#/modules/usage) were not being used at all by the addon due to a logic mistake in the JavaScript. For example, the `css` boolean below made no difference, and the addon kept using the default styles. Likewise, naming specific `source` paths had no effect.

```javascript
// this didn't work
var app = new EmberApp(defaults, {
  // Add options here
  SemanticUI: {
    import: {
      css: false,
    }
  }
});
```

Here's the problem in `index.js`. `options` evaluates to `true` or `{}`, when it should evaluate to to an object of the options, like `{import: { css: false } }`. `getDefault` is a function that tries to traverse the options object, but since options is a boolean, it falls back to the addon defaults.

```
    const options = (app && app.options['SemanticUI']) || (app && app.options['semantic-ui-ember']) || {};
//...
    const importCss = getDefault('import', 'css', [options, defaults])
    if (importCss) {
      const sourceCss = getDefault('source', 'css', [options, defaults])
      app.import({
        development: path.join(sourceCss, 'semantic.css'),
        production: path.join(sourceCss, 'semantic.min.css')
      });
    }
```

## The fix

Do the logical check, and then assign the value of `options`:

```
    let options;
    if (app && app.options['SemanticUI']) {
      options = app.options['SemanticUI']
    } else if (app && app.options['semantic-ui-ember']) {
      options = app.options['semantic-ui-ember']
    } else {
      options = {}
    }
```

I added a test for this. It can be run with `node tape-tests/utils/get-default-test.js`.

## Bug replication & solution example app

Here's how to replicate the bug. Inspect `ember-cli-build.js` of [this example app](https://github.com/jenweber/Semantic-UI-Ember), run it locally, and you'll see that the button styles are Semantic's, when the css should be disabled according to the build options.

```sh
git clone git@github.com:jenweber/semantic-ui-ember-demo.git
cd semantic-ui-ember-demo
npm install
ember serve
```
![screen shot 2019-01-02 at 4 06 19 pm](https://user-images.githubusercontent.com/16627268/50612577-67c88580-0ea8-11e9-9686-0ceddac7c804.png)

Here's the solution in action. Try out the app while using my fork with the bugfix and you will see the styles are disabled as they should be:
```sh
git checkout bugfix-example
npm install
ember serve
```

![screen shot 2019-01-02 at 4 04 32 pm](https://user-images.githubusercontent.com/16627268/50612459-1fa96300-0ea8-11e9-9165-227469646c28.png)

P.S. thanks for your work on this addon!