### PR TITLE
Check MUTABLE_CELL on objectKey.description

### DIFF
--- a/addon/mixins/base.js
+++ b/addon/mixins/base.js
@@ -183,7 +183,10 @@ Semantic.BaseMixin = Ember.Mixin.create({
     // if its a mutable object, get the actual value
     if (typeof value === 'object') {
       let objectKeys = Ember.A(Object.keys(value));
-      if (objectKeys.any((objectkey) => objectkey.indexOf('MUTABLE_CELL') >= 0)) {
+      let objectSymbols = Ember.A(Object.getOwnPropertySymbols(value));
+
+      if (objectKeys.any((objectkey) => objectkey.indexOf('MUTABLE_CELL') >= 0) ||
+          objectSymbols.any(objectSymbol => objectSymbol.description === 'MUTABLE_CELL')) {
         value = Ember.get(value, 'value');
       }
     }


### PR DESCRIPTION
After updating Ember from 3.10 to 3.22, values set in components don't show up properly in semantic-ui elements, because MutableCell object structure changed from using key/value pairs to symbols.